### PR TITLE
Add systemd-python to allow for systemd python interactions in salt-bin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Now clone the repo:
 * cd salt-bin
 
 Inside the repo you will find a collection of requirements files and configs.
-The configuration files are for pop-build and can be found in the conf direcotry.
+The configuration files are for pop-build and can be found in the conf directory.
 
 Inside this directory you can make a "basic" build of salt by just calling
 

--- a/conf/arista.conf
+++ b/conf/arista.conf
@@ -1,3 +1,3 @@
 name: salt
 requirements: conf/arista.txt
-run: conf/default_run.py
+run: conf/arista_run.py

--- a/conf/arista.conf
+++ b/conf/arista.conf
@@ -1,0 +1,3 @@
+name: salt
+requirements: conf/arista.txt
+run: conf/default_run.py

--- a/conf/arista.txt
+++ b/conf/arista.txt
@@ -3,32 +3,14 @@
 ## Cython required for PEP538, 540, UTF-8 issue for 'C' locales
 Cython
 
-salt==3000
+salt
 distro
-
-## the dependencies below should be installed by salt as appropriate
-## otherwise troblesome sync of requirements issues
-## Salt 300 uses embedded tornado
-## Jinja2
-## # This should be changed to msgpack-python for Packages
-## # msgpack-python>0.3,!=0.5.5
-## # msgpack-python>0.5,!=0.5.5
-## msgpack>=0.6.2
-## PyYAML<5.1
-## MarkupSafe
-## requests>=1.0.0
-##
-## tornado>=4.2.1,<6.0; python_version < '3'
-## tornado>=4.2.1,<5.0; python_version >= '3.4'
-##
-## # Required by Tornado to handle threads stuff.
-## futures>=2.0; python_version < '3.0'
-
-## pycryptodomex
-# TODO: Building with a custom openssl 1.1.1 on centos 6 is failing to compile M2Crypto, this should be fixed in the future as M2Crypto is prefered
-#M2Crypto>=0.35.2
 
 # building for Arista
 M2Crypto>=0.35.2
 pyeapi>=0.8.3
-
+napalm
+textfsm
+remote-pdb
+lxml
+systemd-python

--- a/conf/arista.txt
+++ b/conf/arista.txt
@@ -1,0 +1,34 @@
+# building for Arista
+
+## Cython required for PEP538, 540, UTF-8 issue for 'C' locales
+Cython
+
+salt==3000
+distro
+
+## the dependencies below should be installed by salt as appropriate
+## otherwise troblesome sync of requirements issues
+## Salt 300 uses embedded tornado
+## Jinja2
+## # This should be changed to msgpack-python for Packages
+## # msgpack-python>0.3,!=0.5.5
+## # msgpack-python>0.5,!=0.5.5
+## msgpack>=0.6.2
+## PyYAML<5.1
+## MarkupSafe
+## requests>=1.0.0
+##
+## tornado>=4.2.1,<6.0; python_version < '3'
+## tornado>=4.2.1,<5.0; python_version >= '3.4'
+##
+## # Required by Tornado to handle threads stuff.
+## futures>=2.0; python_version < '3.0'
+
+## pycryptodomex
+# TODO: Building with a custom openssl 1.1.1 on centos 6 is failing to compile M2Crypto, this should be fixed in the future as M2Crypto is prefered
+#M2Crypto>=0.35.2
+
+# building for Arista
+M2Crypto>=0.35.2
+pyeapi>=0.8.3
+

--- a/conf/arista_run.py
+++ b/conf/arista_run.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
+
+# Import python libs
+import sys
+
+# Import salt libs
+import salt.scripts
+import salt.utils.platform
+
+AVAIL = (
+        'minion',
+        'call',
+##        'proxy',
+##        'master',
+##        'api',
+##        'cloud',
+##        'cp',
+##        'extend',
+##        'key',
+##        'run',
+##        'ssh',
+##        'support',
+##        'syndic',
+        )
+
+
+def redirect():
+    '''
+    Change the args and redirect to another salt script
+    '''
+    if len(sys.argv) < 2:
+        msg = 'Must pass in a salt command, available commands are:'
+        for cmd in AVAIL:
+            msg += '\n{0}'.format(cmd)
+        print(msg)
+        sys.exit(1)
+    cmd = sys.argv[1]
+    if cmd not in AVAIL:
+        # Fall back to the salt command
+        sys.argv[0] = 'salt'
+        s_fun = salt.scripts.salt_main
+    else:
+        sys.argv[0] = 'salt-{0}'.format(cmd)
+        sys.argv.pop(1)
+        s_fun = getattr(salt.scripts, 'salt_{0}'.format(cmd))
+    s_fun()
+
+
+if __name__ == '__main__':
+    if salt.utils.platform.is_windows():
+        # Since this file does not have a '.py' extension, when running on
+        # Windows, spawning any addional processes will fail due to Python
+        # not being able to load this 'module' in the new process.
+        # Work around this by creating a '.pyc' file which will enable the
+        # spawned process to load this 'module' and proceed.
+        import os.path
+        import py_compile
+        cfile = os.path.splitext(__file__)[0] + '.pyc'
+        if not os.path.exists(cfile):
+            py_compile.compile(__file__, cfile)
+    redirect()


### PR DESCRIPTION
Note all platforms have sufficient versions of systemd-python, using a known systemd-python in salt-bin resolves these issues.